### PR TITLE
Handle Rollback and Close of SQLAlchemy Sessions

### DIFF
--- a/wallace/custom.py
+++ b/wallace/custom.py
@@ -34,7 +34,7 @@ custom_code = Blueprint(
     static_folder='static')
 
 # Initialize the Wallace database.
-session = db.get_session()
+session = db.session
 
 # Connect to the Redis queue for notifications.
 q = Queue(connection=conn)
@@ -51,6 +51,11 @@ try:
 except ImportError:
     print "Error: Could not import experiment."
 
+
+@custom_code.teardown_request
+def shutdown_session(_=None):
+    ''' Rollback and close session at request end '''
+    session.remove()
 
 @custom_code.route('/robots.txt')
 def static_from_root():

--- a/wallace/db.py
+++ b/wallace/db.py
@@ -3,7 +3,12 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy.ext.declarative import declarative_base
+from contextlib import contextmanager
+from functools import wraps
+import logging
 import os
+
+logger = logging.getLogger('wallace.db')
 
 db_url_default = "postgresql://postgres@localhost/wallace"
 db_url = os.environ.get("DATABASE_URL", db_url_default)
@@ -14,6 +19,46 @@ session = scoped_session(sessionmaker(autocommit=False,
 
 Base = declarative_base()
 Base.query = session.query_property()
+
+
+@contextmanager
+def sessions_scope(local_session, commit=False):
+    """Provide a transactional scope around a series of operations."""
+    try:
+        yield local_session
+        if commit:
+            local_session.commit()
+            logger.debug('DB session auto-committed as requested')
+    except:
+        # We log the exception before re-raising it, in case the rollback also
+        # fails
+        logger.exception('Exception during scoped worker transaction, '
+                         'rolling back.')
+        # This rollback is potentially redundant with the remove call below,
+        # depending on how the scoped session is configured, but we'll be
+        # explicit here.
+        local_session.rollback()
+        raise
+    finally:
+        local_session.remove()
+        logger.debug('Session complete, db session closed')
+
+
+def scoped_session_decorator(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        from wallace.db import session as wallace_session
+        with sessions_scope(wallace_session) as session:
+            from psiturk.db import db_session as psi_session
+            with sessions_scope(psi_session) as session_psiturk:
+                # The sessions used in func come from the funcs globals, but
+                # they will be proxied thread locals vars from the session
+                # registry, and will therefore be identical to those returned
+                # by the context managers above.
+                logger.debug('Running worker %s in scoped DB sessions',
+                             func.__name__)
+                return func(*args, **kwargs)
+    return wrapper
 
 
 def init_db(drop_all=False):

--- a/wallace/db.py
+++ b/wallace/db.py
@@ -8,15 +8,12 @@ import os
 db_url_default = "postgresql://postgres@localhost/wallace"
 db_url = os.environ.get("DATABASE_URL", db_url_default)
 engine = create_engine(db_url, pool_size=1000)
-Session = scoped_session(sessionmaker(autoflush=True, bind=engine))
+session = scoped_session(sessionmaker(autocommit=False,
+                                      autoflush=True,
+                                      bind=engine))
 
 Base = declarative_base()
-Base.query = Session.query_property()
-
-
-def get_session():
-    """Return the session."""
-    return Session
+Base.query = session.query_property()
 
 
 def init_db(drop_all=False):
@@ -25,4 +22,4 @@ def init_db(drop_all=False):
         Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
 
-    return Session
+    return session


### PR DESCRIPTION
Adds a handler to rollback and close the session at the end of each request.  Simplifies session passing code.  This should address issue #224