### PR TITLE
Fix a bug with Heroku

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
 """Install Wallace as a command line utility."""
 
 from setuptools import setup
-from wallace.version import __version__
 
 setup_args = dict(
     name='wallace',
-    version=__version__,
+    version="0.7.0",
     description='A platform for experimental evolution',
     url='http://github.com/suchow/Wallace',
     author='Berkeley CoCoSci',


### PR DESCRIPTION
This is a temporary fix for an issue we were seeing with Heroku. When
you install Wallace using setuptools, it imports the version number
from inside the Wallace codebase. That triggers Wallace’s init file,
which imports the database, whose initialization depends on
SQL-Alchemy. That causes an error because sqlalchemy can’t be found.
For now, let’s avoid the morass.