### PR TITLE
Hibernate and awaken apps, rename to whatever

### DIFF
--- a/wallace/command_line.py
+++ b/wallace/command_line.py
@@ -563,7 +563,7 @@ def export(app, local):
             " --app " + id,
             shell=True)
 
-        dump_filename = dump_database(id)
+        dump_path = dump_database(id)
 
         subprocess.call(
             "pg_restore --verbose --clean -d wallace " + id + "/data.dump",
@@ -590,7 +590,7 @@ def export(app, local):
             shell=True)
 
     if not local:
-        os.remove(os.path.join(id, dump_filename))
+        os.remove(os.path.join(id, dump_path))
 
     log("Zipping up the package...")
     shutil.make_archive(os.path.join("data", id + "-data"), "zip", id)

--- a/wallace/command_line.py
+++ b/wallace/command_line.py
@@ -95,10 +95,13 @@ def setup(debug=True, verbose=False, app=None):
             "but the experiment requires v" + wallace_version)
 
     # Generate a unique id for this experiment.
+    id = "w" + str(uuid.uuid4())[0:28]
+
+    # If the user provided an app name, use it everywhere that's user-facing.
     if app:
+        id_long = id
         id = str(app)
-    else:
-        id = "w" + str(uuid.uuid4())[0:28]
+
     log("Running as experiment " + id + "...")
 
     # Copy this directory into a temporary folder, ignoring .git
@@ -116,7 +119,10 @@ def setup(debug=True, verbose=False, app=None):
 
     # Save the experiment id
     with open(os.path.join(dst, "experiment_id.txt"), "w") as file:
-        file.write(id)
+        if app:
+            file.write(id_long)
+        else:
+            file.write(id)
 
     # Zip up the temporary directory and place it in the cwd.
     if not debug:

--- a/wallace/command_line.py
+++ b/wallace/command_line.py
@@ -62,7 +62,7 @@ def wallace():
     pass
 
 
-def setup(debug=True, verbose=False):
+def setup(debug=True, verbose=False, app=None):
     """Check the app and, if it's compatible with Wallace, freeze its state."""
     print_header()
 
@@ -94,7 +94,10 @@ def setup(debug=True, verbose=False):
             "but the experiment requires v" + wallace_version)
 
     # Generate a unique id for this experiment.
-    id = "w" + str(uuid.uuid4())[0:28]
+    if app:
+        id = str(app)
+    else:
+        id = "w" + str(uuid.uuid4())[0:28]
     log("Running as experiment " + id + "...")
 
     # Copy this directory into a temporary folder, ignoring .git
@@ -262,7 +265,7 @@ def deploy_sandbox_shared_setup(verbose=True, web_procs=1):
     else:
         out = open(os.devnull, 'w')
 
-    (id, tmp) = setup(debug=False, verbose=verbose)
+    (id, tmp) = setup(debug=False, verbose=verbose, app=app)
 
     # Log in to Heroku if we aren't already.
     log("Making sure that you are logged in to Heroku.")
@@ -399,7 +402,8 @@ def deploy_sandbox_shared_setup(verbose=True, web_procs=1):
 
 @wallace.command()
 @click.option('--verbose', is_flag=True, flag_value=True, help='Verbose mode')
-def sandbox(verbose):
+@click.option('--app', default=None, help='ID of the sandboxed experiment')
+def sandbox(verbose, app):
     """Deploy app using Heroku to the MTurk Sandbox."""
     # Load psiTurk configuration.
     config = PsiturkConfig()
@@ -413,12 +417,12 @@ def sandbox(verbose):
     config.set("Shell Parameters", "launch_in_sandbox_mode", "true")
 
     # Do shared setup.
-    deploy_sandbox_shared_setup(verbose=verbose)
+    deploy_sandbox_shared_setup(verbose=verbose, app=app)
 
 
 @wallace.command()
 @click.option('--verbose', is_flag=True, flag_value=True, help='Verbose mode')
-def deploy(verbose):
+def deploy(verbose, app):
     """Deploy app using Heroku to MTurk."""
     # Load psiTurk configuration.
     config = PsiturkConfig()
@@ -432,7 +436,7 @@ def deploy(verbose):
     config.set("Shell Parameters", "launch_in_sandbox_mode", "false")
 
     # Do shared setup.
-    deploy_sandbox_shared_setup(verbose=verbose)
+    deploy_sandbox_shared_setup(verbose=verbose, id=app)
 
 
 @wallace.command()


### PR DESCRIPTION
This PR adds two new capabilities:

1. Experiments can be sandboxed and deployed with custom names by using the `--app` parameter. I recommend using this only for sandboxing apps because there is merit in having a globally unique experiment ID.

2. Experiments can now be hibernated (`wallace hibernate`) and awoken (`wallace awaken`). When in hibernation, dynos are scaled down to zero and all costly Heroku addons are removed. The database is stored in an S3 bucket. When awoken, dynos are scaled back up, Heroku addons are readded, and the database is restored from the S3 bucket.